### PR TITLE
Adds a bit of clarity to where the stability fee goes.

### DIFF
--- a/Dai.md
+++ b/Dai.md
@@ -94,7 +94,7 @@ Liquidation ratio is the collateral-to-debt ratio at which a CDP becomes vulnera
 
 ### Stability Fee
 
-The Stability Fee is a fee paid by every CDP. It is defined as a yearly percentage that is calculated on top of the existing debt of the CDP. When the CDP user covers their CDP, the Dai used to cover the CDP debt is destroyed, but the Dai used to pay the Stability Fee is instead sent to Buy&Burn.
+The Stability Fee is a fee paid by every CDP. It is defined as a yearly percentage that is calculated on top of the existing debt of the CDP. When the CDP user covers their CDP, the Dai used to cover the CDP debt is destroyed, but the Dai used to pay the Stability Fee is used to buy MKR, which are then destroyed (see: Buy&Burn)
 A higher Stability Fee represents a higher expected rate of sudden death for the collateral (such as a hack or severe disaster instantly rendering the asset completely worthless).
 
 ### Penalty Ratio


### PR DESCRIPTION
This referenced `Buy&Burn` as though it was a very precisely defined thing that only applies to Maker.  In reality, Buy&Burn and Create&Sell are concepts used throughout the token space, not just with regards to Maker and not specifically related to MKR.  The way this was worded previously, it made it sound like DAI was subject to the Buy&Burn process (which it is when liquidating a CDP) when in reality it is MKR that is being bought (with DAI) and then burned.

The glossary should also be updated to define `Buy&Burn` as a more generic process, which _may_ be applied to MKR in various situations (though it also is applied to DAI within Maker).  Right now this document appears to overload the term `Buy&Burn` to be specific to MKR which is just confusing.